### PR TITLE
Proposal/definition of ready

### DIFF
--- a/docs/definition-of-ready.md
+++ b/docs/definition-of-ready.md
@@ -1,1 +1,5 @@
 # Team Definition of Ready (Proposal)
+
+This document proposes a team wide Defintion of Ready for backlog tiems.
+
+builds on [documented Issue #173](<https://github.com/users/gchwalik/projects/3/views/1?pane=issue&itemId=129055973&issue=gchwalik%7Cpawsitive%7C173>) and will serve as a reference point for sprint planning.

--- a/docs/definition-of-ready.md
+++ b/docs/definition-of-ready.md
@@ -3,3 +3,50 @@
 This document proposes a team wide Defintion of Ready for backlog tiems.
 
 builds on [documented Issue #173](<https://github.com/users/gchwalik/projects/3/views/1?pane=issue&itemId=129055973&issue=gchwalik%7Cpawsitive%7C173>) and will serve as a reference point for sprint planning.
+
+### Principle
+**An item is "Ready" when the assignment can begin immediately with no unresolved blockers**
+
+### Working Ticket Proposal
+1. Outcome - 1-2 sentences naming the user and the value.
+2. Acceptance Criteria (steps 3-7) - include at least one edge/empty/error case.
+3. Size - S/M/L (S≤ 1 day, M ≤ 3 days, split L before starting).
+4. Asset Links - a UI mock or API req/res shape.
+5. Dependencies Managed - name external things work relies on & plan of action/date.
+6. Validation -  3-6 steps a teammate can follow to confirm it works 
+7. Priority Confirmed - team thumbs up.
+
+### Feature overlay
+- Purpose & Success metric goal (latency target etc.)
+- Scope Bounds (what's in/out; first releasable slice)
+- High Level (where does the feature touch in the system & how parts work together; before split into tickets)
+- Story Map (2-6 Tickets) - each should pass the Ticket checklist
+- Rollout & Validation (flag/gradual release and how we will confirm value with metrics, logs etc.)
+- T-shirt Estimate/ Target window (for planning only; non blocking)
+
+
+---
+
+
+
+### Common elements of DOR:
+- **Story is clear, well described, and understood by the team.**
+The work item should have concise and comprehensive descriptions of the what and why. Must include who it is for(end user)
+- **Acceptance criteria are defined, measurable, and testable.**
+Story or feature should have clear conditions that can be testable.
+- **Work is small enough to fit within one iteration.**
+Large work should be split up into smaller tickets to be realistically completed within a sprint.
+- **Any necessary designs, content, or assets are available.**
+If the story requires UI mockups, images, datasets or other assets, they should be accessible to the team before development starts. 
+
+---
+
+### References:
+
+[Scrum Inc. – Definition of Ready](https://www.scruminc.com/definition-of-ready/?utm_source=chatgpt.com)
+
+[Atlassian – Definition of Ready](https://www.atlassian.com/agile/project-management/definition-of-ready?utm_source=chatgpt.com)
+
+[Hyperdrive Agile Guide](https://hyperdriveagile.com/articles/definition-of-ready-in-agile-teams-complete-guide-with-examples-73?utm_source=chatgpt.com)
+
+[Scrum Alliance – Definition vs. Ready](https://resources.scrumalliance.org/article/definition-vs-ready?utm_source=chatgpt.com)

--- a/docs/definition-of-ready.md
+++ b/docs/definition-of-ready.md
@@ -1,0 +1,1 @@
+# Team Definition of Ready (Proposal)


### PR DESCRIPTION
### Team Definition of Ready (Proposal)

## Why
Team definition of ready ensures alignment on what must be in place before work is started. 
This reduces ambiguity, avoids blocked tickets, and helps us consistently plan reliable sprints.

## What's Included
- common elements of DoR across sources ( story clarity, acceptance criteria, dependencies, assets, etc.)
- Scope of readiness at different granularities (ticket, feature, epic).  
- References to external resources for further reading.
