### PR TITLE
#141 - Add pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,66 @@
+<!--
+## Title 
+Issue number, brief description of issue 
+
+Ex: #141 - Add pull request template
+-->
+
+<!--
+⚠️ Note: Sections marked as "Optional" should only be included if they are relevant to your changes.
+-->
+
+## Description
+<!-- 
+Provide a clear and concise description of the changes. 
+Explain the problem this solves or the feature it adds.
+-->
+
+<!--
+## Related Issue
+Link related issue on pr. 
+
+Steps:
+- go to contribution tab of the pr
+- on right hand panel, under  heading Development 
+- search for and link your issue
+-->
+
+## Changes
+<!-- 
+Clearly describe the changes that you made for the issue. 
+
+These might include a description of the functional changes, as well as the main changes you made to the code. 
+
+If relevant, point to the best place in your changeset to start reviewing. Ex: the top-most invoking function for your changes.
+
+This section is included to help the reviewer more quickly 
+understand your changes as well as what to focus on when 
+they're reviewing your code. This is esp useful if the 
+reviewer is unfamiliar with this part of the code. 
+-->
+
+## Notes / Questions  <!-- Optional -->
+<!-- 
+Add any extra context or things reviewers should know. 
+
+Note any questions that you may have about your changes.
+-->
+
+## Screenshots / Videos <!-- Optional -->
+<!-- 
+If applicable, add before/after screenshots or GIFs to show that your functional changes are working. 
+
+Usually screenshots are enough.
+-->
+
+## Testing <!-- Optional -->
+<!-- 
+Describe all the testing you did, whether adding unit tests, manual testing, etc
+
+If relevant, include the steps to manually test your code changes, to confirm it functions as expected.
+-->
+
+## Documentation <!-- Optional -->
+<!--
+Note the places that you updated docs, code comments, etc, if relevant.
+-->


### PR DESCRIPTION
## Description

Adding a pr template, to help clarify what should be documented on prs, both for making reviews easier to get through, and also in case the documentation on a review is relevant to future work.

## Changes
- Added a set of section titles for a given review, as well as descriptions for what each of them should capture.

## Testing
- I need to merge this to main to confirm that this auto-populates for new prs. I'll do that once this review goes through. 
