### PR TITLE
#165 - Add backend linting with ruff

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,10 +1,13 @@
+ARG TARGET_STAGE=dev
+
 # Use the official Python runtime image
-FROM python:3.13-slim
+FROM python:3.13-slim AS base
 
 # Set up environment to avoid creating virtual environments
 ENV UV_SYSTEM_PYTHON=1
+ENV UV_PROJECT_ENVIRONMENT=/usr/local
 
-# Install uv, clean up apt 
+# Install curl and uv, then clean up apt cache
 RUN apt-get update \
   && apt-get install -y curl \
   && rm -rf /var/lib/apt/lists/* \ 
@@ -14,10 +17,13 @@ RUN apt-get update \
 WORKDIR /app
 COPY pyproject.toml uv.lock ./
 
-# run this command to install all dependencies
-ENV UV_PROJECT_ENVIRONMENT=/usr/local
+FROM base AS dev
+RUN uv sync --frozen
+
+FROM base AS prod
 RUN uv sync --frozen --no-dev
 
+FROM $TARGET_STAGE AS final
 # # Copy the Django project to the container
 COPY . .env /app/
 

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -3,16 +3,17 @@
 
 .PHONY: clean exec fmt lint run
 
-PROFILE?=dev  # or prod
+# PROFILE values: dev, prod
+PROFILE?=dev
 
 COMPOSE = docker compose --profile ${PROFILE}
-CONTAINER = backend-pawsitive-${PROFILE}-1
+CONTAINER = backend-pawsitive-${PROFILE}
 
 run:
 	$(COMPOSE) up --build
 
 exec:
-	docker exec -it $(CONTAINER) bash
+	docker exec -it $(CONTAINER)-1 bash
 
 lint:
 	$(COMPOSE) run --build --rm pawsitive-dev ruff check

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,10 +1,24 @@
-.PHONY: run 
+# Set the PROFILE var when calling make [command] to specify the target profile
+# ex: make run PROFILE=prod, make run PROFILE=dev
+
+.PHONY: clean exec run
+
+PROFILE?=dev  # or prod
+
+COMPOSE = docker compose --profile ${PROFILE}
+CONTAINER = backend-pawsitive-${PROFILE}-1
 
 run:
-	docker compose up --build
+	$(COMPOSE) up --build
 
 exec:
-	docker exec -it backend-pawsitive-1 bash
+	docker exec -it $(CONTAINER) bash
+
+lint:
+	$(COMPOSE) run --build --rm pawsitive-dev ruff check
+
+fmt:
+	$(COMPOSE) run --build --rm pawsitive-dev ruff format
 
 clean:
 	docker system prune -f

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,7 +1,7 @@
 # Set the PROFILE var when calling make [command] to specify the target profile
 # ex: make run PROFILE=prod, make run PROFILE=dev
 
-.PHONY: clean exec run
+.PHONY: clean exec fmt lint run
 
 PROFILE?=dev  # or prod
 

--- a/backend/compose.yaml
+++ b/backend/compose.yaml
@@ -14,7 +14,7 @@ services:
   pawsitive-prod:
     <<: *pawsitive-base
     profiles: ["prod"]
-    env_file: ".env" # TODO: set elsewhere
+    env_file: ".env" # TODO: .env shouldn't be used in prod, right now doesn't matter
     build:
       args:
         - TARGET_STAGE=${PROFILE}

--- a/backend/compose.yaml
+++ b/backend/compose.yaml
@@ -1,8 +1,20 @@
+x-pawsitive-base: &pawsitive-base
+  build: .
+  ports:
+    - ${PORT}:${PORT}
+
 services:
-  pawsitive:
+  pawsitive-dev:
+    <<: *pawsitive-base
+    profiles: ["dev"]
     env_file: ".env"
-    build: .
-    ports:
-      - ${PORT}:${PORT}
     volumes:
       - .:/app
+
+  pawsitive-prod:
+    <<: *pawsitive-base
+    profiles: ["prod"]
+    env_file: ".env" # TODO: set elsewhere
+    build:
+      args:
+        - TARGET_STAGE=${PROFILE}

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -21,3 +21,8 @@ build-backend = "hatchling.build"
 
 [tool.uv]
 package = false
+
+[dependency-groups]
+dev = [
+    "ruff>=0.13.2",
+]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -85,6 +85,11 @@ dependencies = [
     { name = "python-dotenv" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "ruff" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "django", specifier = ">=5.2,<6.0" },
@@ -95,6 +100,9 @@ requires-dist = [
     { name = "pygments", specifier = ">=2.19.1,<3.0.0" },
     { name = "python-dotenv", specifier = ">=1.1.0,<2.0.0" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "ruff", specifier = ">=0.13.2" }]
 
 [[package]]
 name = "pygments"
@@ -112,6 +120,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f6/b0/4bc07ccd3572a2f9df7e6782f52b0c6c90dcbb803ac4a167702d7d0dfe1e/python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab", size = 41978, upload-time = "2025-06-24T04:21:07.341Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/ed/539768cf28c661b5b068d66d96a2f155c4971a5d55684a514c1a0e0dec2f/python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc", size = 20556, upload-time = "2025-06-24T04:21:06.073Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.13.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/df/8d7d8c515d33adfc540e2edf6c6021ea1c5a58a678d8cfce9fae59aabcab/ruff-0.13.2.tar.gz", hash = "sha256:cb12fffd32fb16d32cef4ed16d8c7cdc27ed7c944eaa98d99d01ab7ab0b710ff", size = 5416417, upload-time = "2025-09-25T14:54:09.936Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/84/5716a7fa4758e41bf70e603e13637c42cfb9dbf7ceb07180211b9bbf75ef/ruff-0.13.2-py3-none-linux_armv6l.whl", hash = "sha256:3796345842b55f033a78285e4f1641078f902020d8450cade03aad01bffd81c3", size = 12343254, upload-time = "2025-09-25T14:53:27.784Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/77/c7042582401bb9ac8eff25360e9335e901d7a1c0749a2b28ba4ecb239991/ruff-0.13.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ff7e4dda12e683e9709ac89e2dd436abf31a4d8a8fc3d89656231ed808e231d2", size = 13040891, upload-time = "2025-09-25T14:53:31.38Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/15/125a7f76eb295cb34d19c6778e3a82ace33730ad4e6f28d3427e134a02e0/ruff-0.13.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c75e9d2a2fafd1fdd895d0e7e24b44355984affdde1c412a6f6d3f6e16b22d46", size = 12243588, upload-time = "2025-09-25T14:53:33.543Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/eb/0093ae04a70f81f8be7fd7ed6456e926b65d238fc122311293d033fdf91e/ruff-0.13.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cceac74e7bbc53ed7d15d1042ffe7b6577bf294611ad90393bf9b2a0f0ec7cb6", size = 12491359, upload-time = "2025-09-25T14:53:35.892Z" },
+    { url = "https://files.pythonhosted.org/packages/43/fe/72b525948a6956f07dad4a6f122336b6a05f2e3fd27471cea612349fedb9/ruff-0.13.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6ae3f469b5465ba6d9721383ae9d49310c19b452a161b57507764d7ef15f4b07", size = 12162486, upload-time = "2025-09-25T14:53:38.171Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/e3/0fac422bbbfb2ea838023e0d9fcf1f30183d83ab2482800e2cb892d02dfe/ruff-0.13.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4f8f9e3cd6714358238cd6626b9d43026ed19c0c018376ac1ef3c3a04ffb42d8", size = 13871203, upload-time = "2025-09-25T14:53:41.943Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/82/b721c8e3ec5df6d83ba0e45dcf00892c4f98b325256c42c38ef136496cbf/ruff-0.13.2-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:c6ed79584a8f6cbe2e5d7dbacf7cc1ee29cbdb5df1172e77fbdadc8bb85a1f89", size = 14929635, upload-time = "2025-09-25T14:53:43.953Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/a0/ad56faf6daa507b83079a1ad7a11694b87d61e6bf01c66bd82b466f21821/ruff-0.13.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aed130b2fde049cea2019f55deb939103123cdd191105f97a0599a3e753d61b0", size = 14338783, upload-time = "2025-09-25T14:53:46.205Z" },
+    { url = "https://files.pythonhosted.org/packages/47/77/ad1d9156db8f99cd01ee7e29d74b34050e8075a8438e589121fcd25c4b08/ruff-0.13.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1887c230c2c9d65ed1b4e4cfe4d255577ea28b718ae226c348ae68df958191aa", size = 13355322, upload-time = "2025-09-25T14:53:48.164Z" },
+    { url = "https://files.pythonhosted.org/packages/64/8b/e87cfca2be6f8b9f41f0bb12dc48c6455e2d66df46fe61bb441a226f1089/ruff-0.13.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5bcb10276b69b3cfea3a102ca119ffe5c6ba3901e20e60cf9efb53fa417633c3", size = 13354427, upload-time = "2025-09-25T14:53:50.486Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/df/bf382f3fbead082a575edb860897287f42b1b3c694bafa16bc9904c11ed3/ruff-0.13.2-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:afa721017aa55a555b2ff7944816587f1cb813c2c0a882d158f59b832da1660d", size = 13537637, upload-time = "2025-09-25T14:53:52.887Z" },
+    { url = "https://files.pythonhosted.org/packages/51/70/1fb7a7c8a6fc8bd15636288a46e209e81913b87988f26e1913d0851e54f4/ruff-0.13.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:1dbc875cf3720c64b3990fef8939334e74cb0ca65b8dbc61d1f439201a38101b", size = 12340025, upload-time = "2025-09-25T14:53:54.88Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/27/1e5b3f1c23ca5dd4106d9d580e5c13d9acb70288bff614b3d7b638378cc9/ruff-0.13.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:5b939a1b2a960e9742e9a347e5bbc9b3c3d2c716f86c6ae273d9cbd64f193f22", size = 12133449, upload-time = "2025-09-25T14:53:57.089Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/09/b92a5ccee289f11ab128df57d5911224197d8d55ef3bd2043534ff72ca54/ruff-0.13.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:50e2d52acb8de3804fc5f6e2fa3ae9bdc6812410a9e46837e673ad1f90a18736", size = 13051369, upload-time = "2025-09-25T14:53:59.124Z" },
+    { url = "https://files.pythonhosted.org/packages/89/99/26c9d1c7d8150f45e346dc045cc49f23e961efceb4a70c47dea0960dea9a/ruff-0.13.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:3196bc13ab2110c176b9a4ae5ff7ab676faaa1964b330a1383ba20e1e19645f2", size = 13523644, upload-time = "2025-09-25T14:54:01.622Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/00/e7f1501e81e8ec290e79527827af1d88f541d8d26151751b46108978dade/ruff-0.13.2-py3-none-win32.whl", hash = "sha256:7c2a0b7c1e87795fec3404a485096bcd790216c7c146a922d121d8b9c8f1aaac", size = 12245990, upload-time = "2025-09-25T14:54:03.647Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/bd/d9f33a73de84fafd0146c6fba4f497c4565fe8fa8b46874b8e438869abc2/ruff-0.13.2-py3-none-win_amd64.whl", hash = "sha256:17d95fb32218357c89355f6f6f9a804133e404fc1f65694372e02a557edf8585", size = 13324004, upload-time = "2025-09-25T14:54:06.05Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/12/28fa2f597a605884deb0f65c1b1ae05111051b2a7030f5d8a4ff7f4599ba/ruff-0.13.2-py3-none-win_arm64.whl", hash = "sha256:da711b14c530412c827219312b7d7fbb4877fb31150083add7e8c5336549cea7", size = 12484437, upload-time = "2025-09-25T14:54:08.022Z" },
 ]
 
 [[package]]

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -3,7 +3,8 @@
 
 .PHONY: clean debug-build dev exec fmt lint prod restore
 
-PROFILE?=dev # or prod
+# PROFILE values: dev, prod
+PROFILE?=dev
 
 COMPOSE = docker compose --profile ${PROFILE}
 CONTAINER = frontend-pawsitive-${PROFILE}-1

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -1,6 +1,9 @@
+# Set the PROFILE var when calling make [command] to specify the target profile
+# ex: make run PROFILE=prod, make run PROFILE=dev
+
 .PHONY: clean debug-build dev exec fmt lint prod restore
 
-PROFILE?=dev
+PROFILE?=dev # or prod
 
 COMPOSE = docker compose --profile ${PROFILE}
 CONTAINER = frontend-pawsitive-${PROFILE}-1


### PR DESCRIPTION
## Description
Backend doesn't have linting. ruff is a very popular new linting tool, and it is now configured. 

These commands can be executed with `make lint` and `make fmt` from the `/backend/` folder.

## Note
- `ruff` is a dev dependency, as it should only be run during development. Rather than just updating the Makefile to always install dev dependencies, I refactored it to be a multi-stage build.
- copied and modified logic from the frontend makefile and docker compose files 
- note that the actual linting and formatting will be done in a follow up pr

## Changes
- From inside the backend container, ran `uv add --dev ruff` (uv.lock, pyproject.toml)
- Updated Makefile to have multi-stage builds for dev and prod, so that prod doesn't install dev dependencies, but dev does
  - the final stage needs to be set as a var, so setting it as TARGET_STAGE and passing it in from the makefile through the docker compose file 
  - some comments to both frontend and backend makefiles to make clear how to build for prod instead of dev (which is the default)

## Manual testing steps 
* go to the `/backend/` folder 
* run `make run`, then in another terminal run `make exec` and in the container run `ruff`, ruff should be installed 
* run `make run PROFILE=dev`, then in another terminal run `make exec` and in the container run `ruff`, ruff should be installed 
* run `make run PROFILE=prod`, then in another terminal run `make exec PROFILE=prod` and in the container run `ruff`, ruff should not be installed