### PR TITLE
docs: revise Definition of Ready (29th)

### DIFF
--- a/docs/collaboration/definition_of_ready
+++ b/docs/collaboration/definition_of_ready
@@ -1,0 +1,61 @@
+# Team Definition of Ready (Proposal)
+
+This document proposes a team wide Defintion of Ready for backlog tiems.
+
+builds on [documented Issue #173](<https://github.com/users/gchwalik/projects/3/views/1?pane=issue&itemId=129055973&issue=gchwalik%7Cpawsitive%7C173>) and will serve as a reference point for sprint planning.
+
+### Principle
+**An item is "Ready" when the assignment can begin immediately with no unresolved blockers**
+
+---
+
+### Working Ticket Proposal
+1. Outcome - 1-2 sentences naming the user and the value.
+2. Acceptance Criteria (steps 3-7) - include at least one edge/empty/error case.
+3. Size - Ticket must be **M or smaller before starting**. If initially L or larger, it must be split before active work.  
+4. **T-shirt sizing** – Based on **individual velocity** rather than a "senior baseline." Refined further when the ticket is picked up.
+   - XS – < ½ day  
+   - S – ~1 day  
+   - M – 2–3 days  
+   - L – ~1 week (**must break down**)  
+   - XL – 2–3 weeks (**must break down**)  
+   - XXL – very large/unknown (proposal only, **must break down**) 
+4. Asset Links - Provide the **minimum necessary inputs** to unblock work.  
+   - For frontend tickets, a quick sketch (30–40 seconds) is enough.  
+   - If a mockup would be materially useful, create a **separate ticket** and link it.  
+   - Written descriptions or layout notes are acceptable substitutes.  
+5. Dependencies Managed - name external things work relies on & plan of action/date for resolution.
+6. Validation - 3-6 steps a teammate can follow to confirm it works.
+7. Priority Confirmed - product Owner and atleast one team member gives a thumbs up.
+
+### Feature overlay
+- Purpose & Success metric goal - Why are we doing this, and how will success be measured?(latency target etc.)
+- Scope Bounds - Define (what's in/out; first releasable slice)
+- High Level (where does the feature touch in the system & how parts work together; before split into tickets)
+- Story Map (2-6 Tickets) - each should pass the Ticket checklist
+- Rollout & Validation (flag/gradual release and how we will confirm value with metrics, logs etc.)
+- T-shirt Estimate/ Target window - Features get an initial estimate(XL etc. if ealry )(for planning only; before pullen into a sprint) **must break down**
+
+---
+
+### Common elements of DOR:
+- **Story is clear, well described, and understood by the team.**
+The work item should have concise and comprehensive descriptions of the what and why. Must include who it is for(end user)
+- **Acceptance criteria are defined, measurable, and testable.**
+Story or feature should have clear conditions that can be testable.
+- **Work is small enough to fit within one iteration.**
+Large work should be split up into smaller tickets to be realistically completed within a sprint.
+- **Any necessary designs, content, or assets are available.**
+If the story requires UI mockups, images, datasets or other assets, they should be accessible to the team before development starts. 
+
+---
+
+### References:
+
+[Scrum Inc. – Definition of Ready](https://www.scruminc.com/definition-of-ready/?utm_source=chatgpt.com)
+
+[Atlassian – Definition of Ready](https://www.atlassian.com/agile/project-management/definition-of-ready?utm_source=chatgpt.com)
+
+[Hyperdrive Agile Guide](https://hyperdriveagile.com/articles/definition-of-ready-in-agile-teams-complete-guide-with-examples-73?utm_source=chatgpt.com)
+
+[Scrum Alliance – Definition vs. Ready](https://resources.scrumalliance.org/article/definition-vs-ready?utm_source=chatgpt.com)


### PR DESCRIPTION
#173     
Team Definition of Ready (DoR): revised proposal

- Clarified t-shirt sizing based on individual velocity, with approximate ranges
- Lightened assets requirement (quick sketches ok, mockups optional via separate ticket)
- Incorporated feedback revision from team discussion on 9/29 and async team chat in ticket comment