### PR TITLE
#163 - Investigate why the backend docker container takes 10s to stop

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -28,4 +28,4 @@ FROM $TARGET_STAGE AS final
 COPY . .env /app/
 
 # Run Django’s development server
-CMD python manage.py runserver 0.0.0.0:$PORT
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/backend/compose.yaml
+++ b/backend/compose.yaml
@@ -1,7 +1,7 @@
 x-pawsitive-base: &pawsitive-base
   build: .
   ports:
-    - ${PORT}:${PORT}
+    - "${PORT:-8000}:8000"
 
 services:
   pawsitive-dev:


### PR DESCRIPTION
## Description

The backend docker container now stops gracefully, rather than waiting out the SIGTERM 10s and only stopping on a SIGKILL.

## Changes

Inside the docker container, the django app listens on port 8000. We can map internal ports to external ports, so that the host machine can talk to the running apps inside the container. 

I set the port to listen on in the `.env` file in the project root. However, I was having the internal port take this value, as well as the exposed port. The is fragile and unnecessary, so I reverted the internal port to be the default 8000, and set the exposed port to be 8000 by default if the env file doesn't set PORT.

This line in the dockerfile: `CMD python manage.py runserver 0.0.0.0:$PORT`, was creating a bash shell to execute the command, and bash scripts don't forward signals to their children automatically. This meaning the bash script would receive the SIGTERM, but didn't tell the child process (the django server) and the 10s for the SIGTERM would just wait out until the SIGKILL was issued.

Some links:
- https://testdriven.io/tips/9c233ead-5f34-4b95-b416-84f80f3ef5e7/
- https://cloud.theodo.com/en/blog/docker-processes-container#:~:text=status%20of%200.-,What%20happens%20when%20not%20configured%20properly,-If%20your%20container

## Testing
- Pull down this branch
- From the backend folder run `make run`
- Hit `ctrl+c` and it should stop quickly, not taking 10s
